### PR TITLE
[Chat] WebSocket 기반 1:1 채팅 도메인 및 읽음 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,8 @@ dependencies {
     //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
+    //WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/gnu/project/backend/chat/config/ChatSchedulingConfig.java
+++ b/src/main/java/gnu/project/backend/chat/config/ChatSchedulingConfig.java
@@ -1,0 +1,9 @@
+package gnu.project.backend.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class ChatSchedulingConfig {
+}

--- a/src/main/java/gnu/project/backend/chat/config/WebSocketConfig.java
+++ b/src/main/java/gnu/project/backend/chat/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package gnu.project.backend.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-stomp")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+
+        registry.addEndpoint("/ws-stomp")
+                .setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+}

--- a/src/main/java/gnu/project/backend/chat/constant/ChatConstants.java
+++ b/src/main/java/gnu/project/backend/chat/constant/ChatConstants.java
@@ -1,0 +1,9 @@
+// src/main/java/gnu/project/backend/chat/ChatConstants.java
+package gnu.project.backend.chat.constant;
+
+public final class ChatConstants {
+    public static final String ROLE_OWNER = "OWNER";
+    public static final String ROLE_CUSTOMER = "CUSTOMER";
+
+    private ChatConstants() {}
+}

--- a/src/main/java/gnu/project/backend/chat/controller/ChatController.java
+++ b/src/main/java/gnu/project/backend/chat/controller/ChatController.java
@@ -1,0 +1,69 @@
+package gnu.project.backend.chat.controller;
+
+import gnu.project.backend.chat.constant.ChatConstants;
+import gnu.project.backend.chat.controller.docs.ChatDocs;
+import gnu.project.backend.chat.dto.request.ChatMessageRequest;
+import gnu.project.backend.chat.dto.request.ChatRoomCreateRequest;
+import gnu.project.backend.chat.dto.response.ChatMessageResponse;
+import gnu.project.backend.chat.dto.response.ChatRoomListResponse;
+import gnu.project.backend.chat.service.ChatService;
+import gnu.project.backend.common.error.ErrorCode;
+import gnu.project.backend.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class ChatController implements ChatDocs {
+
+    private final ChatService chatService;
+
+    @Override
+    public Long createRoom(@RequestBody ChatRoomCreateRequest request) {
+        return chatService.createRoomByDto(request);
+    }
+
+    @Override
+    public List<ChatRoomListResponse> getOwnerRooms(@PathVariable String ownerId) {
+        return chatService.getRoomsByOwner(ownerId);
+    }
+
+    @Override
+    public List<ChatRoomListResponse> getCustomerRooms(@PathVariable String customerId) {
+        return chatService.getRoomsByCustomer(customerId);
+    }
+
+    @Override
+    public List<ChatMessageResponse> getHistory(
+            @PathVariable Long chatRoomId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "30") int size
+    ) {
+        return chatService.getHistory(chatRoomId, cursor, size);
+    }
+
+    @Override
+    public void readAll(@PathVariable Long chatRoomId, @RequestParam String role) {
+        if (!ChatConstants.ROLE_OWNER.equalsIgnoreCase(role)
+                && !ChatConstants.ROLE_CUSTOMER.equalsIgnoreCase(role)) {
+            throw new BusinessException(ErrorCode.ROLE_IS_NOT_VALID);
+        }
+        chatService.readAll(chatRoomId, role);
+    }
+
+    @Override
+    public ChatMessageResponse sendByRest(@RequestBody ChatMessageRequest request) {
+        return chatService.saveMessage(request);
+    }
+
+    @Override
+    public void deleteRoom(@PathVariable Long chatRoomId,
+                           @RequestParam String role,
+                           @RequestParam String senderId) {
+        chatService.deleteRoomForSide(chatRoomId, role, senderId);
+    }
+
+}

--- a/src/main/java/gnu/project/backend/chat/controller/ChatWsController.java
+++ b/src/main/java/gnu/project/backend/chat/controller/ChatWsController.java
@@ -1,0 +1,26 @@
+// src/main/java/gnu/project/backend/chat/controller/ChatWsController.java
+package gnu.project.backend.chat.controller;
+
+import gnu.project.backend.chat.dto.request.ChatMessageRequest;
+import gnu.project.backend.chat.dto.response.ChatMessageResponse;
+import gnu.project.backend.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatWsController {
+
+    private final ChatService chatService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat.message")
+    public void handleMessage(ChatMessageRequest request) {
+        ChatMessageResponse saved = chatService.saveMessage(request);
+        messagingTemplate.convertAndSend("/sub/chatroom/" + saved.chatRoomId(), saved);
+    }
+}

--- a/src/main/java/gnu/project/backend/chat/controller/docs/ChatDocs.java
+++ b/src/main/java/gnu/project/backend/chat/controller/docs/ChatDocs.java
@@ -1,0 +1,52 @@
+// src/main/java/gnu/project/backend/chat/controller/docs/ChatDocs.java
+package gnu.project.backend.chat.controller.docs;
+
+import gnu.project.backend.chat.dto.request.ChatMessageRequest;
+import gnu.project.backend.chat.dto.request.ChatRoomCreateRequest;
+import gnu.project.backend.chat.dto.response.ChatMessageResponse;
+import gnu.project.backend.chat.dto.response.ChatRoomListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Chat", description = "채팅 API")
+public interface ChatDocs {
+
+    @Operation(summary = "채팅방 생성/가져오기")
+    @PostMapping("/rooms")
+    Long createRoom(@RequestBody ChatRoomCreateRequest request);
+
+    @Operation(summary = "오너 채팅방 목록")
+    @GetMapping("/rooms/owner/{ownerId}")
+    List<ChatRoomListResponse> getOwnerRooms(@PathVariable String ownerId);
+
+    @Operation(summary = "고객 채팅방 목록")
+    @GetMapping("/rooms/customer/{customerId}")
+    List<ChatRoomListResponse> getCustomerRooms(@PathVariable String customerId);
+
+    @Operation(summary = "채팅 히스토리 조회 (페이징)")
+    @GetMapping("/history/{chatRoomId}")
+    List<ChatMessageResponse> getHistory(
+            @PathVariable Long chatRoomId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "30") int size
+    );
+
+    @Operation(summary = "채팅방 읽음 처리")
+    @PostMapping("/rooms/{chatRoomId}/read")
+    void readAll(@PathVariable Long chatRoomId, @RequestParam String role);
+
+    @Operation(summary = "테스트용 REST 메시지 전송")
+    @PostMapping("/messages")
+    ChatMessageResponse sendByRest(@RequestBody ChatMessageRequest request);
+
+    @Operation(summary = "채팅방 한쪽만 숨기기(소프트 삭제)")
+    @DeleteMapping("/rooms/{chatRoomId}")
+    void deleteRoom(
+            @PathVariable Long chatRoomId,
+            @RequestParam String role,
+            @RequestParam String senderId
+    );
+}

--- a/src/main/java/gnu/project/backend/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/gnu/project/backend/chat/dto/request/ChatMessageRequest.java
@@ -1,0 +1,9 @@
+// src/main/java/gnu/project/backend/chat/dto/request/ChatMessageRequest.java
+package gnu.project.backend.chat.dto.request;
+
+public record ChatMessageRequest(
+        Long chatRoomId,
+        String senderRole,
+        String senderId,
+        String message
+) {}

--- a/src/main/java/gnu/project/backend/chat/dto/request/ChatRoomCreateRequest.java
+++ b/src/main/java/gnu/project/backend/chat/dto/request/ChatRoomCreateRequest.java
@@ -1,0 +1,6 @@
+package gnu.project.backend.chat.dto.request;
+
+public record ChatRoomCreateRequest(
+        String ownerId,
+        String customerId
+) {}

--- a/src/main/java/gnu/project/backend/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/gnu/project/backend/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,16 @@
+package gnu.project.backend.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageResponse(
+        Long chatRoomId,
+        String senderRole,
+        String senderId,
+        String message,
+        LocalDateTime sendTime,
+        boolean ownerRead,
+        boolean customerRead,
+        LocalDateTime ownerReadAt,
+        LocalDateTime customerReadAt,
+        Long messageId
+) {}

--- a/src/main/java/gnu/project/backend/chat/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/gnu/project/backend/chat/dto/response/ChatRoomListResponse.java
@@ -1,0 +1,13 @@
+package gnu.project.backend.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomListResponse(
+        Long chatRoomId,
+        String opponentId,
+        String opponentName,
+        String opponentProfileImage,
+        String lastMessage,
+        LocalDateTime lastMessageTime,
+        long unreadCount
+) {}

--- a/src/main/java/gnu/project/backend/chat/entity/ChatRoom.java
+++ b/src/main/java/gnu/project/backend/chat/entity/ChatRoom.java
@@ -1,0 +1,41 @@
+package gnu.project.backend.chat.entity;
+
+import gnu.project.backend.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "chat_room")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "owner_id", nullable = false)
+    private String ownerId;
+
+    @Column(name = "customer_id", nullable = false)
+    private String customerId;
+
+    @Column(name = "owner_deleted", nullable = false)
+    private boolean ownerDeleted = false;
+
+    @Column(name = "customer_deleted", nullable = false)
+    private boolean customerDeleted = false;
+
+    @Builder
+    private ChatRoom(String ownerId, String customerId) {
+        this.ownerId = ownerId;
+        this.customerId = customerId;
+    }
+
+    public void deleteByOwner() {
+        this.ownerDeleted = true;
+    }
+
+    public void deleteByCustomer() {
+        this.customerDeleted = true;
+    }
+}

--- a/src/main/java/gnu/project/backend/chat/entity/Chatting.java
+++ b/src/main/java/gnu/project/backend/chat/entity/Chatting.java
@@ -1,0 +1,79 @@
+// src/main/java/gnu/project/backend/chat/entity/Chatting.java
+package gnu.project.backend.chat.entity;
+
+import gnu.project.backend.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chatting")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chatting extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @Column(nullable = false, length = 1000)
+    private String message;
+
+    // 누가 보냈는지 역할
+    @Column(name = "sender_role", nullable = false, length = 50)
+    private String senderRole; // OWNER | CUSTOMER
+
+    // 실제 사용자 식별자 (email, userId 등)
+    @Column(name = "sender_id", nullable = false, length = 255)
+    private String senderId;
+
+    @Column(name = "send_time", nullable = false)
+    private LocalDateTime sendTime;
+
+    @Column(name = "owner_read", nullable = false)
+    private boolean ownerRead;
+
+    @Column(name = "owner_read_at")
+    private LocalDateTime ownerReadAt;
+
+    @Column(name = "customer_read", nullable = false)
+    private boolean customerRead;
+
+    @Column(name = "customer_read_at")
+    private LocalDateTime customerReadAt;
+
+    @Builder
+    private Chatting(ChatRoom chatRoom,
+                     String message,
+                     String senderRole,
+                     String senderId,
+                     LocalDateTime sendTime,
+                     boolean ownerRead,
+                     LocalDateTime ownerReadAt,
+                     boolean customerRead,
+                     LocalDateTime customerReadAt) {
+        this.chatRoom = chatRoom;
+        this.message = message;
+        this.senderRole = senderRole;
+        this.senderId = senderId;
+        this.sendTime = sendTime;
+        this.ownerRead = ownerRead;
+        this.ownerReadAt = ownerReadAt;
+        this.customerRead = customerRead;
+        this.customerReadAt = customerReadAt;
+    }
+
+    public void readByOwner(LocalDateTime now) {
+        this.ownerRead = true;
+        this.ownerReadAt = now;
+    }
+
+    public void readByCustomer(LocalDateTime now) {
+        this.customerRead = true;
+        this.customerReadAt = now;
+    }
+}

--- a/src/main/java/gnu/project/backend/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/gnu/project/backend/chat/repository/ChatRoomQueryRepository.java
@@ -1,0 +1,10 @@
+package gnu.project.backend.chat.repository;
+
+import gnu.project.backend.chat.dto.response.ChatRoomListResponse;
+
+import java.util.List;
+
+public interface ChatRoomQueryRepository {
+    List<ChatRoomListResponse> findRoomsByOwner(String ownerId);
+    List<ChatRoomListResponse> findRoomsByCustomer(String customerId);
+}

--- a/src/main/java/gnu/project/backend/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/gnu/project/backend/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,14 @@
+// src/main/java/gnu/project/backend/chat/repository/ChatRoomRepository.java
+package gnu.project.backend.chat.repository;
+
+import gnu.project.backend.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomQueryRepository {
+    Optional<ChatRoom> findByOwnerIdAndCustomerId(String ownerId, String customerId);
+
+    List<ChatRoom> findByOwnerDeletedIsTrueAndCustomerDeletedIsTrue();
+}

--- a/src/main/java/gnu/project/backend/chat/repository/ChattingQueryRepository.java
+++ b/src/main/java/gnu/project/backend/chat/repository/ChattingQueryRepository.java
@@ -1,0 +1,14 @@
+package gnu.project.backend.chat.repository;
+
+import gnu.project.backend.chat.entity.Chatting;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ChattingQueryRepository {
+    int bulkReadByOwner(Long chatRoomId, LocalDateTime now);
+    int bulkReadByCustomer(Long chatRoomId, LocalDateTime now);
+
+    // 페이징
+    List<Chatting> findPage(Long chatRoomId, Long lastId, int size);
+}

--- a/src/main/java/gnu/project/backend/chat/repository/ChattingRepository.java
+++ b/src/main/java/gnu/project/backend/chat/repository/ChattingRepository.java
@@ -1,0 +1,17 @@
+package gnu.project.backend.chat.repository;
+
+import gnu.project.backend.chat.entity.Chatting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface ChattingRepository extends JpaRepository<Chatting, Long>, ChattingQueryRepository {
+    List<Chatting> findByChatRoomIdOrderBySendTimeAsc(Long chatRoomId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Chatting c where c.chatRoom.id in :roomIds")
+    void deleteByChatRoomIds(Collection<Long> roomIds);
+}

--- a/src/main/java/gnu/project/backend/chat/repository/impl/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/gnu/project/backend/chat/repository/impl/ChatRoomQueryRepositoryImpl.java
@@ -1,0 +1,86 @@
+package gnu.project.backend.chat.repository.impl;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gnu.project.backend.chat.constant.ChatConstants;
+import gnu.project.backend.chat.dto.response.ChatRoomListResponse;
+import gnu.project.backend.chat.entity.QChatRoom;
+import gnu.project.backend.chat.entity.QChatting;
+import gnu.project.backend.chat.repository.ChatRoomQueryRepository;
+import gnu.project.backend.customer.entity.QCustomer;
+import gnu.project.backend.owner.entity.QOwner;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<ChatRoomListResponse> findRoomsByOwner(String ownerId) {
+        QChatRoom cr = QChatRoom.chatRoom;
+        QChatting ct = QChatting.chatting;
+        QCustomer cu = QCustomer.customer;
+
+        return query
+                .select(Projections.constructor(
+                        ChatRoomListResponse.class,
+                        cr.id,
+                        cr.customerId,
+                        cu.oauthInfo.name,
+                        Expressions.nullExpression(String.class),
+                        ct.message.max(),
+                        ct.sendTime.max(),
+                        new CaseBuilder()
+                                .when(ct.senderRole.ne(ChatConstants.ROLE_OWNER)
+                                        .and(ct.ownerRead.isFalse()))
+                                .then(1L)
+                                .otherwise(0L)
+                                .sum()
+                ))
+                .from(cr)
+                .leftJoin(ct).on(ct.chatRoom.eq(cr))
+                .leftJoin(cu).on(cu.oauthInfo.socialId.eq(cr.customerId))
+                .where(cr.ownerId.eq(ownerId), cr.ownerDeleted.isFalse())
+                .groupBy(cr.id, cr.customerId, cu.oauthInfo.name)
+                .orderBy(ct.sendTime.max().desc().nullsLast())
+                .fetch();
+    }
+
+    @Override
+    public List<ChatRoomListResponse> findRoomsByCustomer(String customerId) {
+        QChatRoom cr = QChatRoom.chatRoom;
+        QChatting ct = QChatting.chatting;
+        QOwner ow = QOwner.owner;
+
+        return query
+                .select(Projections.constructor(
+                        ChatRoomListResponse.class,
+                        cr.id,
+                        cr.ownerId,
+                        ow.oauthInfo.name,
+                        ow.profileImage,
+                        ct.message.max(),
+                        ct.sendTime.max(),
+                        new CaseBuilder()
+                                .when(ct.senderRole.ne(ChatConstants.ROLE_CUSTOMER)
+                                        .and(ct.customerRead.isFalse()))
+                                .then(1L)
+                                .otherwise(0L)
+                                .sum()
+                ))
+                .from(cr)
+                .leftJoin(ct).on(ct.chatRoom.eq(cr))
+                .leftJoin(ow).on(ow.oauthInfo.socialId.eq(cr.ownerId))
+                .where(cr.customerId.eq(customerId),cr.customerDeleted.isFalse())
+                .groupBy(cr.id, cr.ownerId, ow.oauthInfo.name, ow.profileImage)
+                .orderBy(ct.sendTime.max().desc().nullsLast())
+                .fetch();
+    }
+}

--- a/src/main/java/gnu/project/backend/chat/repository/impl/ChattingQueryRepositoryImpl.java
+++ b/src/main/java/gnu/project/backend/chat/repository/impl/ChattingQueryRepositoryImpl.java
@@ -1,0 +1,61 @@
+package gnu.project.backend.chat.repository.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gnu.project.backend.chat.entity.Chatting;
+import gnu.project.backend.chat.entity.QChatting;
+import gnu.project.backend.chat.repository.ChattingQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ChattingQueryRepositoryImpl implements ChattingQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public int bulkReadByOwner(Long chatRoomId, LocalDateTime now) {
+        QChatting ct = QChatting.chatting;
+        return (int) query
+                .update(ct)
+                .set(ct.ownerRead, true)
+                .set(ct.ownerReadAt, now)
+                .where(
+                        ct.chatRoom.id.eq(chatRoomId),
+                        ct.ownerRead.isFalse()
+                )
+                .execute();
+    }
+
+    @Override
+    public int bulkReadByCustomer(Long chatRoomId, LocalDateTime now) {
+        QChatting ct = QChatting.chatting;
+        return (int) query
+                .update(ct)
+                .set(ct.customerRead, true)
+                .set(ct.customerReadAt, now)
+                .where(
+                        ct.chatRoom.id.eq(chatRoomId),
+                        ct.customerRead.isFalse()
+                )
+                .execute();
+    }
+
+    @Override
+    public List<Chatting> findPage(Long chatRoomId, Long lastId, int size) {
+        QChatting ct = QChatting.chatting;
+
+        return query
+                .selectFrom(ct)
+                .where(
+                        ct.chatRoom.id.eq(chatRoomId),
+                        lastId != null ? ct.id.lt(lastId) : null
+                )
+                .orderBy(ct.id.desc())
+                .limit(size)
+                .fetch();
+    }
+}

--- a/src/main/java/gnu/project/backend/chat/scheduler/ChatCleanupScheduler.java
+++ b/src/main/java/gnu/project/backend/chat/scheduler/ChatCleanupScheduler.java
@@ -1,0 +1,40 @@
+package gnu.project.backend.chat.scheduler;
+
+import gnu.project.backend.chat.entity.ChatRoom;
+import gnu.project.backend.chat.repository.ChatRoomRepository;
+import gnu.project.backend.chat.repository.ChattingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatCleanupScheduler {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChattingRepository chattingRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void purgeFullyDeletedRooms() {
+        List<ChatRoom> rooms = chatRoomRepository.findByOwnerDeletedIsTrueAndCustomerDeletedIsTrue();
+        if (rooms.isEmpty()) {
+            return;
+        }
+
+        var roomIds = rooms.stream().map(ChatRoom::getId).toList();
+        log.info("[ChatCleanup] target rooms: {}", roomIds);
+
+        // 1) 메시지 먼저 삭제
+        chattingRepository.deleteByChatRoomIds(roomIds);
+        // 2) 방 삭제
+        chatRoomRepository.deleteAllById(roomIds);
+
+        log.info("[ChatCleanup] deleted {} rooms", roomIds.size());
+    }
+}

--- a/src/main/java/gnu/project/backend/chat/service/ChatService.java
+++ b/src/main/java/gnu/project/backend/chat/service/ChatService.java
@@ -1,0 +1,231 @@
+package gnu.project.backend.chat.service;
+
+import gnu.project.backend.chat.constant.ChatConstants;
+import gnu.project.backend.chat.dto.request.ChatMessageRequest;
+import gnu.project.backend.chat.dto.request.ChatRoomCreateRequest;
+import gnu.project.backend.chat.dto.response.ChatMessageResponse;
+import gnu.project.backend.chat.dto.response.ChatRoomListResponse;
+import gnu.project.backend.chat.entity.ChatRoom;
+import gnu.project.backend.chat.entity.Chatting;
+import gnu.project.backend.chat.repository.ChatRoomRepository;
+import gnu.project.backend.chat.repository.ChattingRepository;
+import gnu.project.backend.common.enumerated.UserRole;
+import gnu.project.backend.common.error.ErrorCode;
+import gnu.project.backend.common.exception.BusinessException;
+import gnu.project.backend.customer.entity.Customer;
+import gnu.project.backend.customer.repository.CustomerRepository;
+import gnu.project.backend.owner.entity.Owner;
+import gnu.project.backend.owner.repository.OwnerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChattingRepository chattingRepository;
+
+    // 실제 사용자 존재/ROLE 확인용
+    private final OwnerRepository ownerRepository;
+    private final CustomerRepository customerRepository;
+
+    /**
+     * ownerId, customerId 조합으로만 방을 만든다.
+     * (역순 매칭은 제거)
+     */
+    public Long createOrGetRoom(String ownerId, String customerId) {
+        return chatRoomRepository.findByOwnerIdAndCustomerId(ownerId, customerId)
+                .map(ChatRoom::getId)
+                .orElseGet(() -> {
+                    ChatRoom room = ChatRoom.builder()
+                            .ownerId(ownerId)
+                            .customerId(customerId)
+                            .build();
+                    chatRoomRepository.save(room);
+                    return room.getId();
+                });
+    }
+
+    public ChatMessageResponse saveMessage(ChatMessageRequest req) {
+        ChatRoom room = chatRoomRepository.findById(req.chatRoomId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST));
+
+        // 1) 우리 시스템에 실제로 있는 유저인지 + ROLE이 맞는지
+        verifySender(req.senderRole(), req.senderId());
+
+        // 2) 그 유저가 이 방의 멤버가 맞는지
+        validateParticipant(room, req.senderRole(), req.senderId());
+
+        LocalDateTime now = LocalDateTime.now();
+
+        boolean ownerRead = false;
+        boolean customerRead = false;
+        LocalDateTime ownerReadAt = null;
+        LocalDateTime customerReadAt = null;
+
+        if (ChatConstants.ROLE_OWNER.equalsIgnoreCase(req.senderRole())) {
+            ownerRead = true;
+            ownerReadAt = now;
+        } else if (ChatConstants.ROLE_CUSTOMER.equalsIgnoreCase(req.senderRole())) {
+            customerRead = true;
+            customerReadAt = now;
+        }
+
+        Chatting chatting = Chatting.builder()
+                .chatRoom(room)
+                .message(req.message())
+                .senderRole(req.senderRole())
+                .senderId(req.senderId())
+                .sendTime(now)
+                .ownerRead(ownerRead)
+                .ownerReadAt(ownerReadAt)
+                .customerRead(customerRead)
+                .customerReadAt(customerReadAt)
+                .build();
+
+        chattingRepository.save(chatting);
+
+        return new ChatMessageResponse(
+                room.getId(),
+                chatting.getSenderRole(),
+                chatting.getSenderId(),
+                chatting.getMessage(),
+                chatting.getSendTime(),
+                chatting.isOwnerRead(),
+                chatting.isCustomerRead(),
+                chatting.getOwnerReadAt(),
+                chatting.getCustomerReadAt(),
+                chatting.getId()
+        );
+    }
+
+    /**
+     * 실제 owner/customer 엔티티로 검증
+     */
+    private void verifySender(String senderRole, String senderSocialId) {
+        if (senderRole == null || senderSocialId == null) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+
+        if (ChatConstants.ROLE_OWNER.equalsIgnoreCase(senderRole)) {
+            Owner owner = ownerRepository.findByOauthInfo_SocialId(senderSocialId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.OWNER_NOT_FOUND_EXCEPTION));
+
+            if (owner.getUserRole() != UserRole.OWNER) {
+                throw new BusinessException(ErrorCode.ROLE_IS_NOT_VALID);
+            }
+            return;
+        }
+
+        if (ChatConstants.ROLE_CUSTOMER.equalsIgnoreCase(senderRole)) {
+            Customer customer = customerRepository.findByOauthInfo_SocialId(senderSocialId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CUSTOMER_NOT_FOUND_EXCEPTION));
+
+            if (!customer.isActive()) {
+                throw new BusinessException(ErrorCode.CUSTOMER_DELETED_EXCEPTION);
+            }
+            if (customer.getUserRole() != UserRole.CUSTOMER) {
+                throw new BusinessException(ErrorCode.ROLE_IS_NOT_VALID);
+            }
+            return;
+        }
+
+        throw new BusinessException(ErrorCode.ROLE_IS_NOT_VALID);
+    }
+
+    /**
+     * 방에 저장돼 있는 owner_id / customer_id 와도 일치하는지 확인
+     */
+    private void validateParticipant(ChatRoom room, String senderRole, String senderId) {
+        if (ChatConstants.ROLE_OWNER.equalsIgnoreCase(senderRole)) {
+            if (!senderId.equals(room.getOwnerId())) {
+                throw new BusinessException(ErrorCode.AUTH_FORBIDDEN);
+            }
+            return;
+        }
+
+        if (ChatConstants.ROLE_CUSTOMER.equalsIgnoreCase(senderRole)) {
+            if (!senderId.equals(room.getCustomerId())) {
+                throw new BusinessException(ErrorCode.AUTH_FORBIDDEN);
+            }
+            return;
+        }
+
+        throw new BusinessException(ErrorCode.ROLE_IS_NOT_VALID);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomListResponse> getRoomsByOwner(String ownerId) {
+        return chatRoomRepository.findRoomsByOwner(ownerId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomListResponse> getRoomsByCustomer(String customerId) {
+        return chatRoomRepository.findRoomsByCustomer(customerId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatMessageResponse> getHistory(Long chatRoomId, Long cursor, int size) {
+        return chattingRepository.findPage(chatRoomId, cursor, size)
+                .stream()
+                .map(c -> new ChatMessageResponse(
+                        chatRoomId,
+                        c.getSenderRole(),
+                        c.getSenderId(),
+                        c.getMessage(),
+                        c.getSendTime(),
+                        c.isOwnerRead(),
+                        c.isCustomerRead(),
+                        c.getOwnerReadAt(),
+                        c.getCustomerReadAt(),
+                        c.getId()
+                ))
+                .toList();
+    }
+
+    public void readAll(Long chatRoomId, String role) {
+        if (role == null) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+        LocalDateTime now = LocalDateTime.now();
+
+        if (ChatConstants.ROLE_OWNER.equalsIgnoreCase(role)) {
+            chattingRepository.bulkReadByOwner(chatRoomId, now);
+            return;
+        }
+        if (ChatConstants.ROLE_CUSTOMER.equalsIgnoreCase(role)) {
+            chattingRepository.bulkReadByCustomer(chatRoomId, now);
+            return;
+        }
+
+        throw new BusinessException(ErrorCode.ROLE_IS_NOT_VALID);
+    }
+
+    public Long createRoomByDto(ChatRoomCreateRequest request) {
+        return createOrGetRoom(request.ownerId(), request.customerId());
+    }
+
+    public void deleteRoomForSide(Long chatRoomId, String role, String senderId) {
+        ChatRoom room = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST));
+
+        // 내가 그 방 사람 맞는지도 한 번 더
+        validateParticipant(room, role, senderId);
+
+        if (ChatConstants.ROLE_OWNER.equalsIgnoreCase(role)) {
+            room.deleteByOwner();
+            return;
+        }
+        if (ChatConstants.ROLE_CUSTOMER.equalsIgnoreCase(role)) {
+            room.deleteByCustomer();
+            return;
+        }
+        throw new BusinessException(ErrorCode.ROLE_IS_NOT_VALID);
+    }
+}


### PR DESCRIPTION
1. 작업 요약

WebSocket(STOMP) 기반으로 Owner–Customer 간 1:1 채팅을 만들고, 메시지 단위 읽음처리와 한쪽만 삭제하는 플로우를 추가했습니다. 두 쪽 모두 삭제한 채팅방은 매일 00시에 스케줄러로 실제 삭제됩니다.

2. 주요 변경 사항

엔티티

ChatRoom

ownerId, customerId(= 각 엔티티 social_id)

ownerDeleted, customerDeleted 필드 추가 → 각자만 숨기기

Chatting

senderRole(OWNER | CUSTOMER)

senderId(실제 social_id)

ownerRead, ownerReadAt

customerRead, customerReadAt

DTO

ChatMessageRequest(chatRoomId, senderRole, senderId, message)

ChatMessageResponse(...)

ChatRoomListResponse(chatRoomId, opponentId, opponentName, opponentProfileImage, lastMessage, lastMessageTime, unreadCount)

Repository / QueryDSL

ChatRoomQueryRepositoryImpl

오너 기준 목록: customer 조인해서 이름만 노출, ownerDeleted = false 조건 추가

고객 기준 목록: owner 조인해서 이름/프로필 노출, customerDeleted = false 조건 추가

미읽음 개수는 senderRole != 내롤 AND 내읽음=false 합계로 계산

ChattingQueryRepositoryImpl

방 입장 시 일괄 읽음 update (owner/customer 각각)

위로 스크롤용 페이징 조회

Service

saveMessage(...)

요청한 senderRole/senderId가 실제 Owner/Customer 테이블에 있는지 1차 검증

그 사용자가 이 방의 당사자(ownerId/customerId)인지 2차 검증

본인이 보낸 메시지는 본인 read 플래그 즉시 true

readAll(chatRoomId, role)

방 들어갔을 때 내 쪽 메시지 일괄 읽음

deleteRoomForSide(chatRoomId, role, senderId)

내 쪽만 soft delete

컨트롤러

REST

POST /api/chat/rooms 방 생성/가져오기

GET /api/chat/rooms/owner/{ownerId}

GET /api/chat/rooms/customer/{customerId}

GET /api/chat/history/{chatRoomId}?cursor=&size=

POST /api/chat/rooms/{chatRoomId}/read?role=...

DELETE /api/chat/rooms/{chatRoomId}?role=...&senderId=...

POST /api/chat/messages (테스트용 REST 전송)

WebSocket

endpoint: /ws-stomp

pub: /pub/chat.message

sub: /sub/chatroom/{chatRoomId}

스케줄러

ChatSchedulingConfig에 @EnableScheduling

ChatCleanupScheduler

cron: 0 0 0 * * * (Asia/Seoul)

ownerDeleted = true AND customerDeleted = true 인 방만 찾아서

먼저 해당 방 메시지 delete

그 다음 방 delete

3. 핵심 로직

이중 검증

senderRole/senderId → 실제 유저 테이블과 매칭

그 senderId가 이 채팅방의 ownerId/customerId와 같은지 확인
→ 둘 중 하나라도 틀리면 AUTH_FORBIDDEN

미읽음 계산

오너 목록: senderRole != 'OWNER' AND ownerRead = false

고객 목록: senderRole != 'CUSTOMER' AND customerRead = false

한쪽 삭제

오너가 지우면 owner_deleted = true → 고객은 계속 봄

고객이 지우면 customer_deleted = true → 오너는 계속 봄

둘 다 true 되면 자정에 물리 삭제

4. API

WebSocket SEND (예시)

{
  "chatRoomId": 1,
  "senderRole": "CUSTOMER",
  "senderId": "sAkPP6of7GjkkwDzncxhXcv5N3A_4NMUDsdso5XbNcs",
  "message": "예약 문의드립니다."
}

5. ETC

Swagger용 Controller/Docs 분리 유지

프론트는 방 만들 때 넣은 social_id랑 똑같이 메시지 전송해야 함 (문자열 1:1 매칭)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 실시간 채팅 기능 추가: WebSocket을 통한 즉시 메시지 송수신 지원
  * 채팅방 관리: 채팅방 생성, 조회, 삭제 기능 추가
  * 채팅 이력 조회: 페이지네이션을 통한 과거 메시지 검색
  * 메시지 읽음 상태 추적: 역할별 읽음 상태 및 시간 기록
  * REST API 제공: WebSocket 외 HTTP를 통한 메시지 송수신

* **개선 사항**
  * 완전히 삭제된 채팅방의 자동 정리 스케줄러 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->