### PR TITLE
[WeddingHall] 목록/상세/생성 흐름 리팩토링 및 필터·페이지네이션 확장

### DIFF
--- a/src/main/java/gnu/project/backend/mock/WeddingHallDataGenerator.java
+++ b/src/main/java/gnu/project/backend/mock/WeddingHallDataGenerator.java
@@ -3,13 +3,17 @@ package gnu.project.backend.mock;
 import gnu.project.backend.auth.enumerated.SocialProvider;
 import gnu.project.backend.owner.entity.Owner;
 import gnu.project.backend.owner.repository.OwnerRepository;
+import gnu.project.backend.product.entity.Image;
 import gnu.project.backend.product.entity.Option;
 import gnu.project.backend.product.entity.Tag;
 import gnu.project.backend.product.entity.WeddingHall;
 import gnu.project.backend.product.enumerated.Region;
+import gnu.project.backend.product.repository.ImageRepository;
 import gnu.project.backend.product.repository.OptionRepository;
 import gnu.project.backend.product.repository.TagRepository;
 import gnu.project.backend.product.repository.WeddingHallRepository;
+import java.util.List;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
@@ -17,8 +21,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Component
@@ -31,76 +33,122 @@ public class WeddingHallDataGenerator implements CommandLineRunner {
     private final WeddingHallRepository weddingHallRepository;
     private final OptionRepository optionRepository;
     private final TagRepository tagRepository;
+    private final ImageRepository imageRepository;
+
+    // ✅ 네가 실제 토큰으로 생성한 Owner 정보(로그에서 봤던 값들)
+    private static final String OWNER_EMAIL     = "74r2k@naver.com";
+    private static final String OWNER_NAME      = "김용환";
+    private static final String OWNER_SOCIAL_ID = "sAkPP6of7GjkkwDzncxhXcv5N3A_4NMUDsdso5XbNcs";
+    private static final SocialProvider PROVIDER = SocialProvider.NAVER;
+
+    private static final String[] NAMES = {
+            "루체하우스","라발스","라산체플","블리스가든","라움","더파티움","라비제","아모르",
+            "마리앤코","베라체","노블발렌티","라센느","에스카르고","더엘","메종드미디어",
+            "벨라지오","헤르츠","엘블레스","라포레","오페라하우스","엘리시아","베네치아",
+            "라메르","디오디아","드포엠","브라이드밸리","더리버","루체","라포레스트","더그레이스"
+    };
+    private static final String[] AVAILABLE_TIME_TEMPLATES = {
+            "10:00-12:00,14:00-16:00",
+            "09:00-11:00 ,13:00-15:00",
+            "11:00-13:00,  15:00-17:00"
+    };
+    private static final String[] POLICY_TEMPLATES = {
+            "예약금은 총 금액의 10%이며 환불 규정은 계약서 기준을 따릅니다.",
+            "행사 7일 전 전액 환불, 3일 전 50% 환불, 1일 전 환불 불가.",
+            "변경 및 취소는 영업일 기준으로 처리됩니다.",
+            "천재지변 등 불가항력 사유는 별도 규정을 적용합니다."
+    };
+    private static final Region[] REGIONS = {
+            Region.SEOUL, Region.BUSAN, Region.GYEONGGI, Region.ETC
+    };
+
+    private final Random random = new Random();
 
     @Override
     @Transactional
     public void run(String... args) {
 
-        // 1) social-owner-1 이라는 socialId 가진 Owner 확보 (없으면 생성)
-        Owner owner = ownerRepository.findByOauthInfo_SocialId("social-owner-1")
-            .orElseGet(() -> {
-                Owner newOwner = Owner.createFromOAuth(
-                    "owner1@example.com",   // email
-                    "로컬오너",              // 이름/닉네임
-                    "social-owner-1",       // !!! 중요: 소셜아이디
-                    SocialProvider.KAKAO    // provider
-                );
-                return ownerRepository.save(newOwner);
-            });
+        Owner owner = ownerRepository.findByOauthInfo_SocialId(OWNER_SOCIAL_ID)
+                .orElseGet(() -> ownerRepository.save(
+                        Owner.createFromOAuth(OWNER_EMAIL, OWNER_NAME, OWNER_SOCIAL_ID, PROVIDER)
+                ));
 
-        // 2) 이미 그 오너 소유 웨딩홀이 있으면 중복생성 안 함
-        long hallCount = weddingHallRepository.countActiveByOwner("social-owner-1");
-        if (hallCount > 0) {
-            log.info("[local seed] wedding hall already exists for social-owner-1, skip seeding");
+        long existing = weddingHallRepository.countActiveByOwner(OWNER_SOCIAL_ID);
+        if (existing >= 30) {
+            log.info("[local seed] wedding halls already >= 30 for {}, skip (existing={})",
+                    OWNER_SOCIAL_ID, existing);
             return;
         }
 
-        // 3) 웨딩홀 엔티티 생성/저장
-        WeddingHall hall = WeddingHall.create(
-            owner,
-            1_500_000, // price
-            "서울 강남구 청담동 123-4",
-            "화이트 톤 메인홀, 주차 넉넉, 버진로드 김사장 직영",
-            "블루밍웨딩홀",
-            200,       // capacity
-            50,        // minGuest
-            250,       // maxGuest
-            1,         // hallType 코드 (int)
-            80,        // parkingCapacity
-            "뷔페",     // cateringType
-            "10:00-12:00,14:00-16:00", // availableTimes
-            "예약금 30%, 행사 한 달 전 취소시 전액 환불",
-            Region.SEOUL// reservationPolicy
-        );
-        hall = weddingHallRepository.save(hall);
+        // 3) 30개 생성
+        for (int i = 0; i < 30; i++) {
+            String name = NAMES[i % NAMES.length];
+            Region region = REGIONS[i % REGIONS.length];
 
-        // 4) 옵션들 생성/저장 + 양방향 세팅
-        Option opt1 = Option.ofCreate(
-            hall,
-            "생화데코 패키지",
-            300_000,
-            "신부대기실 포함 / 메인홀 플라워 연출"
-        );
-        Option opt2 = Option.ofCreate(
-            hall,
-            "기본 음향/조명",
-            0,
-            "마이크 2대, 기본 스팟 조명 포함"
-        );
-        optionRepository.saveAll(List.of(opt1, opt2));
-        hall.addAllOption(List.of(opt1, opt2));
+            String availableTimes = normalizeAvailableTimes(
+                    AVAILABLE_TIME_TEMPLATES[random.nextInt(AVAILABLE_TIME_TEMPLATES.length)]
+            );
 
-        // 5) 태그들 생성/저장 + 양방향 세팅
-        Tag tag1 = Tag.ofCreate(hall, "채광좋음");
-        Tag tag2 = Tag.ofCreate(hall, "대형홀");
-        tagRepository.saveAll(List.of(tag1, tag2));
-        hall.addAllTag(List.of(tag1, tag2));
+            WeddingHall hall = WeddingHall.create(
+                    owner,
+                    900_000 + random.nextInt(600_000),                // price
+                    "서울시 어딘가 " + (i + 1),                        // address
+                    "웨딩홀 상세 설명 " + (i + 1),                      // detail
+                    name,                                             // name
+                    150 + random.nextInt(250),                        // capacity
+                    50 + random.nextInt(80),                          // minGuest
+                    200 + random.nextInt(300),                        // maxGuest
+                    30 + random.nextInt(120),                         // parkingCapacity
+                    "뷔페",                                            // cateringType
+                    availableTimes,                                   // availableTimes
+                    POLICY_TEMPLATES[random.nextInt(POLICY_TEMPLATES.length)], // reservationPolicy
+                    region,                                           // region
+                    (i % 2 == 0),                                     // subwayAccessible
+                    (i % 3 != 0)                                      // diningAvailable
+            );
+            hall = weddingHallRepository.save(hall);
 
-        // (이미지 목업도 원하면 Image.ofCreate(...) 비슷하게 만들어서 넣고
-        //   hall.addImage(image); imageRepository.save(image);
-        //   이러면 thumbnailUrl도 리스트 응답에서 채워짐)
+            // 썸네일/이미지
+            Image thumb = Image.ofCreate(
+                    hall,
+                    "https://picsum.photos/seed/hall-" + (i+1) + "-thumb/800/600",
+                    "MOCK/hall-" + (i+1) + "/thumb.jpg",
+                    0
+            );
+            Image img1 = Image.ofCreate(
+                    hall,
+                    "https://picsum.photos/seed/hall-" + (i+1) + "-a/1024/768",
+                    "MOCK/hall-" + (i+1) + "/a.jpg",
+                    1
+            );
+            Image img2 = Image.ofCreate(
+                    hall,
+                    "https://picsum.photos/seed/hall-" + (i+1) + "-b/1024/768",
+                    "MOCK/hall-" + (i+1) + "/b.jpg",
+                    2
+            );
+            imageRepository.saveAll(List.of(thumb, img1, img2));
+            hall.addImage(thumb);
+            hall.addImage(img1);
+            hall.addImage(img2);
 
-        log.info("[local seed] wedding hall seeded for owner social-owner-1, hallId={}",
-            hall.getId());
+            // 옵션/태그
+            Option opt1 = Option.ofCreate(hall, "생화데코 패키지", 300_000, "신부대기실 포함 / 메인홀 플라워 연출");
+            Option opt2 = Option.ofCreate(hall, "기본 음향/조명", 0, "마이크 2대, 기본 스팟 조명 포함");
+            optionRepository.saveAll(List.of(opt1, opt2));
+            hall.addAllOption(List.of(opt1, opt2));
+
+            Tag tag1 = Tag.ofCreate(hall, "채광좋음");
+            Tag tag2 = Tag.ofCreate(hall, "대형홀");
+            tagRepository.saveAll(List.of(tag1, tag2));
+            hall.addAllTag(List.of(tag1, tag2));
+        }
+
+        log.info("[local seed] wedding halls seeded (target=30, owner={})", OWNER_SOCIAL_ID);
+    }
+
+    private String normalizeAvailableTimes(final String raw) {
+        if (raw == null) return null;
+        return raw.trim().replaceAll("\\s*,\\s*", ", "); // 쉼표 뒤 한 칸
     }
 }

--- a/src/main/java/gnu/project/backend/owner/entity/Owner.java
+++ b/src/main/java/gnu/project/backend/owner/entity/Owner.java
@@ -99,4 +99,13 @@ public class Owner extends BaseEntity implements OauthUser {
         this.bzNumber = bzNumber;
         this.bankAccount = bankAccount;
     }
+
+    public String getDisplayName() {
+        if (this.bzName != null && !this.bzName.isBlank()) {
+            return this.bzName;
+        }
+        return this.getOauthInfo() != null ? this.getOauthInfo().getName() : null;
+    }
+
+
 }

--- a/src/main/java/gnu/project/backend/product/controller/WeddingHallController.java
+++ b/src/main/java/gnu/project/backend/product/controller/WeddingHallController.java
@@ -31,86 +31,66 @@ public class WeddingHallController implements WeddingHallDocs {
     @Override
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<WeddingHallResponse> createWeddingHall(
-        @Parameter(hidden = true) @Auth final Accessor accessor,
-        @Valid @RequestPart("request") final WeddingHallRequest request,
-        @RequestPart(name = "images", required = false) final List<MultipartFile> images
+            @Parameter(hidden = true) @Auth final Accessor accessor,
+            @Valid @RequestPart("request") final WeddingHallRequest request,
+            @RequestPart(name = "images", required = false) final List<MultipartFile> images
     ) {
         return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(
-                weddingHallService.create(
-                    request,
-                    images,
-                    accessor
-                )
-            );
+                .status(HttpStatus.CREATED)
+                .body(weddingHallService.create(request, images, accessor));
     }
 
     @Override
-    @PatchMapping(
-        value = "/{id}",
-        consumes = MediaType.MULTIPART_FORM_DATA_VALUE
-    )
+    @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<WeddingHallResponse> updateWeddingHall(
-        @Parameter(hidden = true) @Auth final Accessor accessor,
-        @PathVariable("id") final Long id,
-        @Valid @RequestPart("request") final WeddingHallUpdateRequest request,
-        @RequestPart(name = "images", required = false) final List<MultipartFile> images
+            @Parameter(hidden = true) @Auth final Accessor accessor,
+            @PathVariable("id") final Long id,
+            @Valid @RequestPart("request") final WeddingHallUpdateRequest request,
+            @RequestPart(name = "images", required = false) final List<MultipartFile> images
     ) {
-        return ResponseEntity
-            .ok(
-                weddingHallService.update(
-                    id,
-                    request,
-                    images,
-                    request.keepImagesId(), // 기존 이미지 유지 목록
-                    accessor
-                )
-            );
+        return ResponseEntity.ok(
+                weddingHallService.update(id, request, images, request.keepImagesId(), accessor)
+        );
     }
 
     @Override
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteWeddingHall(
-        @Parameter(hidden = true) @Auth final Accessor accessor,
-        @PathVariable("id") final Long id
+            @Parameter(hidden = true) @Auth final Accessor accessor,
+            @PathVariable("id") final Long id
     ) {
-        return ResponseEntity.ok(
-            weddingHallService.delete(id, accessor)
-        );
+        return ResponseEntity.ok(weddingHallService.delete(id, accessor));
     }
 
     @Override
     @GetMapping("/{id}")
-    public ResponseEntity<WeddingHallResponse> readWeddingHall(
-        @PathVariable("id") final Long id
-    ) {
-        return ResponseEntity.ok(
-            weddingHallService.read(id)
-        );
+    public ResponseEntity<WeddingHallResponse> readWeddingHall(@PathVariable("id") final Long id) {
+        return ResponseEntity.ok(weddingHallService.read(id));
     }
 
     @Override
     @GetMapping
     public ResponseEntity<Page<WeddingHallPageResponse>> readWeddingHalls(
-        @RequestParam(name = "pageNumber", required = false, defaultValue = "1") final Integer pageNumber,
-        @RequestParam(name = "pageSize", required = false, defaultValue = "6") final Integer pageSize,
-        @RequestParam(name = "region", required = false) final Region region
+            @RequestParam(name = "pageNumber", defaultValue = "1") final Integer pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "6") final Integer pageSize,
+            @RequestParam(name = "region", required = false) final Region region,
+            @RequestParam(name = "subwayAccessible", required = false) final Boolean subwayAccessible,
+            @RequestParam(name = "diningAvailable", required = false) final Boolean diningAvailable
     ) {
         return ResponseEntity.ok(
-            weddingHallService.readWeddingHalls(pageNumber, pageSize, region)
+                weddingHallService.readWeddingHalls(pageNumber, pageSize, region, subwayAccessible, diningAvailable)
         );
     }
 
     @Override
     @GetMapping("/me")
     public ResponseEntity<Page<WeddingHallPageResponse>> readMyWeddingHalls(
-        @Parameter(hidden = true) @Auth final Accessor accessor,
-        @RequestParam(name = "pageNumber", required = false, defaultValue = "1") final Integer pageNumber,
-        @RequestParam(name = "pageSize", required = false, defaultValue = "6") final Integer pageSize
+            @Parameter(hidden = true) @Auth final Accessor accessor,
+            @RequestParam(name = "pageNumber", defaultValue = "1") final Integer pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "6") final Integer pageSize
     ) {
         return ResponseEntity.ok(
-            weddingHallService.readMyWeddingHalls(accessor, pageNumber, pageSize)
+                weddingHallService.readMyWeddingHalls(accessor, pageNumber, pageSize)
         );
     }
 }

--- a/src/main/java/gnu/project/backend/product/controller/docs/WeddingHallDocs.java
+++ b/src/main/java/gnu/project/backend/product/controller/docs/WeddingHallDocs.java
@@ -21,116 +21,64 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@Tag(
-    name = "WeddingHall API",
-    description = "웨딩홀 상품 CRUD 및 마이페이지 전용 조회 API"
-)
+@Tag(name = "WeddingHall API", description = "웨딩홀 상품 CRUD 및 조회 API")
 public interface WeddingHallDocs {
 
-    @Operation(
-        summary = "웨딩홀 생성",
-        description = "오너가 새 웨딩홀 상품을 등록한다. request(JSON) + images(files[]) 멀티파트 업로드.",
-        responses = {
-            @ApiResponse(
-                responseCode = "201",
-                description = "생성 성공",
-                content = @Content(schema = @Schema(implementation = WeddingHallResponse.class))
-            )
-        }
-    )
+    @Operation(summary = "웨딩홀 생성", description = "오너 등록. request(JSON) + images(files[]) 멀티파트 업로드.")
+    @ApiResponse(responseCode = "201", description = "생성 성공",
+            content = @Content(schema = @Schema(implementation = WeddingHallResponse.class)))
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<WeddingHallResponse> createWeddingHall(
-        @Parameter(hidden = true) @Auth Accessor accessor,
-        @RequestPart("request") WeddingHallRequest request,
-        @RequestPart(name = "images", required = false) List<MultipartFile> images
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @RequestPart("request") WeddingHallRequest request,
+            @RequestPart(name = "images", required = false) List<MultipartFile> images
     );
 
-    @Operation(
-        summary = "웨딩홀 수정",
-        description = "기존 웨딩홀 수정. 새 이미지 업로드 / 기존 이미지 유지 / 옵션, 태그 갱신 등.",
-        responses = {
-            @ApiResponse(
-                responseCode = "200",
-                description = "수정 성공",
-                content = @Content(schema = @Schema(implementation = WeddingHallResponse.class))
-            )
-        }
-    )
-    @PatchMapping(value = "/{id}",
-        consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "웨딩홀 수정", description = "이미지/옵션/태그/기본정보 갱신")
+    @ApiResponse(responseCode = "200", description = "수정 성공",
+            content = @Content(schema = @Schema(implementation = WeddingHallResponse.class)))
+    @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<WeddingHallResponse> updateWeddingHall(
-        @Parameter(hidden = true) @Auth Accessor accessor,
-        @PathVariable("id") Long id,
-        @RequestPart("request") WeddingHallUpdateRequest request,
-        @RequestPart(name = "images", required = false) List<MultipartFile> images
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @PathVariable("id") Long id,
+            @RequestPart("request") WeddingHallUpdateRequest request,
+            @RequestPart(name = "images", required = false) List<MultipartFile> images
     );
 
-    @Operation(
-        summary = "웨딩홀 삭제",
-        description = "소프트 삭제. isDeleted=true 로만 바뀌고 실제로는 안 지움.",
-        responses = {
-            @ApiResponse(
-                responseCode = "200",
-                description = "삭제 성공",
-                content = @Content(schema = @Schema(implementation = String.class))
-            )
-        }
-    )
+    @Operation(summary = "웨딩홀 삭제", description = "소프트 삭제(isDeleted=true)")
+    @ApiResponse(responseCode = "200", description = "삭제 성공")
     @DeleteMapping("/{id}")
     ResponseEntity<String> deleteWeddingHall(
-        @Parameter(hidden = true) @Auth Accessor accessor,
-        @PathVariable("id") Long id
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @PathVariable("id") Long id
     );
 
-    @Operation(
-        summary = "웨딩홀 상세 조회",
-        description = "단일 웨딩홀 상세. 이미지, 옵션, 태그 등 전부 포함.",
-        responses = {
-            @ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content = @Content(schema = @Schema(implementation = WeddingHallResponse.class))
-            )
-        }
-    )
+    @Operation(summary = "웨딩홀 상세 조회", description = "이미지/옵션/태그 포함 상세")
+    @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = WeddingHallResponse.class)))
     @GetMapping("/{id}")
-    ResponseEntity<WeddingHallResponse> readWeddingHall(
-        @PathVariable("id") Long id
-    );
+    ResponseEntity<WeddingHallResponse> readWeddingHall(@PathVariable("id") Long id);
 
-    @Operation(
-        summary = "웨딩홀 전체 목록 조회",
-        description = "공개 리스트 조회. 페이징으로 카드 뿌릴 때 사용.",
-        responses = {
-            @ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content = @Content(schema = @Schema(implementation = Page.class))
-            )
-        }
-    )
+    @Operation(summary = "웨딩홀 목록 조회",
+            description = "공개 리스트 조회. 최신순(updatedAt DESC). region/subway/dining 필터 지원")
+    @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = Page.class)))
     @GetMapping
     ResponseEntity<Page<WeddingHallPageResponse>> readWeddingHalls(
-        @RequestParam(name = "pageNumber", required = false, defaultValue = "1") Integer pageNumber,
-        @RequestParam(name = "pageSize", required = false, defaultValue = "6") Integer pageSize,
-        @RequestParam(name = "region", required = false) final Region region
+            @RequestParam(name = "pageNumber", defaultValue = "1") Integer pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "6") Integer pageSize,
+            @RequestParam(name = "region", required = false) Region region,
+            @RequestParam(name = "subwayAccessible", required = false) Boolean subwayAccessible,
+            @RequestParam(name = "diningAvailable", required = false) Boolean diningAvailable
     );
 
-    @Operation(
-        summary = "내 웨딩홀 목록 조회 (오너 전용)",
-        description = "로그인한 오너(Accessor)의 웨딩홀들만 페이징해서 가져온다. 마이페이지용.",
-        responses = {
-            @ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content = @Content(schema = @Schema(implementation = Page.class))
-            )
-        }
-    )
+    @Operation(summary = "내 웨딩홀 목록", description = "오너 본인 소유 상품")
+    @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = Page.class)))
     @GetMapping("/me")
     ResponseEntity<Page<WeddingHallPageResponse>> readMyWeddingHalls(
-        @Parameter(hidden = true) @Auth Accessor accessor,
-        @RequestParam(name = "pageNumber", required = false, defaultValue = "1") Integer pageNumber,
-        @RequestParam(name = "pageSize", required = false, defaultValue = "6") Integer pageSize
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @RequestParam(name = "pageNumber", defaultValue = "1") Integer pageNumber,
+            @RequestParam(name = "pageSize", defaultValue = "6") Integer pageSize
     );
 }

--- a/src/main/java/gnu/project/backend/product/dto/request/WeddingHallRequest.java
+++ b/src/main/java/gnu/project/backend/product/dto/request/WeddingHallRequest.java
@@ -11,44 +11,46 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record WeddingHallRequest(
-    @NotBlank(message = NAME_REQUIRED)
-    @Size(max = MAX_NAME_LENGTH, message = NAME_LENGTH)
-    String name,
+        @NotBlank(message = NAME_REQUIRED)
+        @Size(max = MAX_NAME_LENGTH, message = NAME_LENGTH)
+        String name,
 
-    @NotNull(message = PRICE_REQUIRED)
-    @Min(value = MIN_PRICE, message = PRICE_MIN)
-    Integer price,
+        @NotNull(message = PRICE_REQUIRED)
+        @Min(value = MIN_PRICE, message = PRICE_MIN)
+        Integer price,
 
-    @NotBlank(message = ADDRESS_REQUIRED)
-    @Size(max = MAX_ADDRESS_LENGTH, message = ADDRESS_LENGTH)
-    String address,
+        @NotBlank(message = ADDRESS_REQUIRED)
+        @Size(max = MAX_ADDRESS_LENGTH, message = ADDRESS_LENGTH)
+        String address,
 
-    @NotBlank(message = DETAIL_REQUIRED)
-    @Size(max = MAX_DETAIL_LENGTH, message = DETAIL_LENGTH)
-    String detail,
+        @NotBlank(message = DETAIL_REQUIRED)
+        @Size(max = MAX_DETAIL_LENGTH, message = DETAIL_LENGTH)
+        String detail,
 
-    @Size(max = MAX_AVAILABLE_TIMES, message = AVAILABLE_TIMES_LENGTH)
-    String availableTimes,
+        @Size(max = MAX_AVAILABLE_TIMES, message = AVAILABLE_TIMES_LENGTH)
+        String availableTimes,
 
-    Integer capacity,
-    Integer minGuest,
-    Integer maxGuest,
-    Integer hallType,
-    Integer parkingCapacity,
+        Integer capacity,
+        Integer minGuest,
+        Integer maxGuest,
+        Integer parkingCapacity,
 
-    @Size(max = 100)
-    String cateringType,
+        @Size(max = 100)
+        String cateringType,
 
-    String reservationPolicy,
+        String reservationPolicy,
 
-    @NotNull(message = REGION_REQUIRE)
-    Region region,
+        @NotNull(message = REGION_REQUIRE)
+        Region region,
 
-    List<TagRequest> tags,
+        boolean subwayAccessible,
+        boolean diningAvailable,
 
-    @Valid
-    @Size(max = MAX_OPTION_COUNT, message = OPTION_LIMIT)
-    List<OptionCreateRequest> options
+        List<TagRequest> tags,
+
+        @Valid
+        @Size(max = MAX_OPTION_COUNT, message = OPTION_LIMIT)
+        List<OptionCreateRequest> options
 
 ) {
 

--- a/src/main/java/gnu/project/backend/product/dto/request/WeddingHallUpdateRequest.java
+++ b/src/main/java/gnu/project/backend/product/dto/request/WeddingHallUpdateRequest.java
@@ -12,46 +12,48 @@ import java.util.List;
 
 public record WeddingHallUpdateRequest(
 
-    @NotNull(message = PRICE_REQUIRED)
-    @Min(value = MIN_PRICE, message = PRICE_MIN)
-    Integer price,
+        @NotNull(message = PRICE_REQUIRED)
+        @Min(value = MIN_PRICE, message = PRICE_MIN)
+        Integer price,
 
-    @NotBlank(message = ADDRESS_REQUIRED)
-    @Size(max = MAX_ADDRESS_LENGTH, message = ADDRESS_LENGTH)
-    String address,
+        @NotBlank(message = ADDRESS_REQUIRED)
+        @Size(max = MAX_ADDRESS_LENGTH, message = ADDRESS_LENGTH)
+        String address,
 
-    @NotBlank(message = DETAIL_REQUIRED)
-    @Size(max = MAX_DETAIL_LENGTH, message = DETAIL_LENGTH)
-    String detail,
+        @NotBlank(message = DETAIL_REQUIRED)
+        @Size(max = MAX_DETAIL_LENGTH, message = DETAIL_LENGTH)
+        String detail,
 
-    @NotBlank(message = NAME_REQUIRED)
-    @Size(max = MAX_NAME_LENGTH, message = NAME_LENGTH)
-    String name,
+        @NotBlank(message = NAME_REQUIRED)
+        @Size(max = MAX_NAME_LENGTH, message = NAME_LENGTH)
+        String name,
 
-    @Size(max = MAX_AVAILABLE_TIMES, message = AVAILABLE_TIMES_LENGTH)
-    String availableTimes,
+        @Size(max = MAX_AVAILABLE_TIMES, message = AVAILABLE_TIMES_LENGTH)
+        String availableTimes,
 
-    Integer capacity,
-    Integer minGuest,
-    Integer maxGuest,
-    Integer hallType,
-    Integer parkingCapacity,
+        Integer capacity,
+        Integer minGuest,
+        Integer maxGuest,
+        Integer parkingCapacity,
 
-    @Size(max = 100)
-    String cateringType,
+        @Size(max = 100)
+        String cateringType,
 
-    String reservationPolicy,
+        String reservationPolicy,
 
-    @NotNull(message = REGION_REQUIRE)
-    Region region,
+        @NotNull(message = REGION_REQUIRE)
+        Region region,
 
-    List<TagRequest> tags,
+        boolean subwayAccessible,
+        boolean diningAvailable,
 
-    @Valid
-    @Size(max = MAX_OPTION_COUNT, message = OPTION_LIMIT)
-    List<OptionUpdateRequest> options,
+        List<TagRequest> tags,
 
-    List<Long> keepImagesId
+        @Valid
+        @Size(max = MAX_OPTION_COUNT, message = OPTION_LIMIT)
+        List<OptionUpdateRequest> options,
+
+        List<Long> keepImagesId
 ) {
 
 }

--- a/src/main/java/gnu/project/backend/product/dto/response/WeddingHallPageResponse.java
+++ b/src/main/java/gnu/project/backend/product/dto/response/WeddingHallPageResponse.java
@@ -7,18 +7,20 @@ import java.util.List;
 
 
 public record WeddingHallPageResponse(
-    Long id,
-    String name,
-    Double starCount,
-    String address,
-    String detail,
-    Integer price,
-    Integer hallType,
-    String availableTime,
-    LocalDateTime createdAt,
-    String thumbnail,
-    Region region,
-    List<WeddingHallResponse.TagResponse> tags
+        Long id,
+        String name,
+        Double starCount,
+        String address,
+        String detail,
+        Integer price,
+        String availableTime,
+        LocalDateTime createdAt,
+        String thumbnail,
+        Region region,
+        String ownerName,
+        boolean subwayAccessible,
+        boolean diningAvailable,
+        List<WeddingHallResponse.TagResponse> tags
 ) {
 
 }

--- a/src/main/java/gnu/project/backend/product/dto/response/WeddingHallResponse.java
+++ b/src/main/java/gnu/project/backend/product/dto/response/WeddingHallResponse.java
@@ -8,110 +8,72 @@ import java.util.List;
 
 
 public record WeddingHallResponse(
-    Long id,
-    String name,
-    Integer price,
-    String address,
-    String detail,
-    String availableTimes,
-
-    double starCount,
-    Integer averageRating,
-
-    Integer capacity,
-    Integer minGuest,
-    Integer maxGuest,
-    Integer hallType,
-    Integer parkingCapacity,
-    String cateringType,
-    String reservationPolicy,
-    Region region,
-
-    // ===== 연관 데이터 =====
-    List<ImageResponse> images,
-    List<OptionResponse> options,
-    List<String> tags
-
-) {
-
-    public static WeddingHallResponse from(final WeddingHall hall) {
-        return new WeddingHallResponse(
-            hall.getId(),
-            hall.getName(),
-            hall.getPrice(),
-            hall.getAddress(),
-            hall.getDetail(),
-            hall.getAvailableTimes(),
-
-            hall.getStarCount(),
-            hall.getAverageRating(),
-
-            hall.getCapacity(),
-            hall.getMinGuest(),
-            hall.getMaxGuest(),
-            hall.getHallType(),
-            hall.getParkingCapacity(),
-            hall.getCateringType(),
-            hall.getReservationPolicy(),
-            hall.getRegion(),
-
-            hall.getImages()
-                .stream()
-                .map(img -> new ImageResponse(
-                    img.getId(),
-                    img.getUrl(),
-                    img.getDisplayOrder(),
-                    img.isThumbnail()
-                ))
-                .toList(),
-
-            hall.getOptions()
-                .stream()
-                .map(opt -> new OptionResponse(
-                    opt.getId(),
-                    opt.getName(),
-                    opt.getPrice(),
-                    opt.getDetail()
-                ))
-                .toList(),
-
-            hall.getTags()
-                .stream()
-                .map(Tag::getName)
-                .toList()
-        );
-    }
-
-    // 서브 DTO들 (Response 전용)
-    public record ImageResponse(
-        Long id,
-        String url,
-        Integer displayOrder,
-        boolean isThumbnail
-    ) {
-
-    }
-
-    public record OptionResponse(
         Long id,
         String name,
         Integer price,
-        String detail
-    ) {
+        String address,
+        String detail,
+        String availableTimes,
 
+        double starCount,
+        Integer averageRating,
+
+        Integer capacity,
+        Integer minGuest,
+        Integer maxGuest,
+        Integer parkingCapacity,
+        String cateringType,
+        String reservationPolicy,
+        Region region,
+
+        String ownerName,
+        boolean subwayAccessible,
+        boolean diningAvailable,
+
+        List<ImageResponse> images,
+        List<OptionResponse> options,
+        List<String> tags
+) {
+
+    public static WeddingHallResponse from(final WeddingHall hall) {
+        final String ownerName = hall.getOwner() != null ? hall.getOwner().getDisplayName() : null;
+
+        return new WeddingHallResponse(
+                hall.getId(),
+                hall.getName(),
+                hall.getPrice(),
+                hall.getAddress(),
+                hall.getDetail(),
+                hall.getAvailableTimes(),
+
+                hall.getStarCount(),
+                hall.getAverageRating(),
+
+                hall.getCapacity(),
+                hall.getMinGuest(),
+                hall.getMaxGuest(),
+                hall.getParkingCapacity(),
+                hall.getCateringType(),
+                hall.getReservationPolicy(),
+                hall.getRegion(),
+
+                ownerName,
+                hall.isSubwayAccessible(),
+                hall.isDiningAvailable(),
+
+                hall.getImages().stream()
+                        .map(img -> new ImageResponse(img.getId(), img.getUrl(), img.getDisplayOrder(), img.isThumbnail()))
+                        .toList(),
+                hall.getOptions().stream()
+                        .map(opt -> new OptionResponse(opt.getId(), opt.getName(), opt.getPrice(), opt.getDetail()))
+                        .toList(),
+                hall.getTags().stream().map(Tag::getName).toList()
+        );
     }
 
-    public record TagResponse(
-        Long id,
-        String tagName
-    ) {
-
-        public static TagResponse from(Tag tag) {
-            return new TagResponse(
-                tag.getId(),
-                tag.getName()
-            );
-        }
+    public record ImageResponse(Long id, String url, Integer displayOrder, boolean isThumbnail) {}
+    public record OptionResponse(Long id, String name, Integer price, String detail) {}
+    public record TagResponse(Long id, String tagName) {
+        public static TagResponse from(Tag tag) { return new TagResponse(tag.getId(), tag.getName()); }
     }
-
 }

--- a/src/main/java/gnu/project/backend/product/entity/WeddingHall.java
+++ b/src/main/java/gnu/project/backend/product/entity/WeddingHall.java
@@ -1,18 +1,10 @@
 package gnu.project.backend.product.entity;
 
-
 import gnu.project.backend.owner.entity.Owner;
 import gnu.project.backend.product.enumerated.Category;
 import gnu.project.backend.product.enumerated.Region;
-import jakarta.persistence.Column;
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "wedding_hall")
@@ -31,9 +23,6 @@ public class WeddingHall extends Product {
     @Column(name = "max_guest")
     private Integer maxGuest;
 
-    @Column(name = "hall_type")
-    private Integer hallType;
-
     @Column(name = "parking_capacity")
     private Integer parkingCapacity;
 
@@ -44,100 +33,90 @@ public class WeddingHall extends Product {
     @Column(name = "reservation_policy")
     private String reservationPolicy;
 
+    // ✅ 새 필터 컬럼
+    @Column(name = "subway_accessible", nullable = false)
+    private boolean subwayAccessible;
+
+    @Column(name = "dining_available", nullable = false)
+    private boolean diningAvailable;
 
     private WeddingHall(
-        Owner owner,
-        Integer price,
-        String address,
-        String detail,
-        String name,
-        Integer capacity,
-        Integer minGuest,
-        Integer maxGuest,
-        Integer hallType,
-        Integer parkingCapacity,
-        String cateringType,
-        String availableTimes,
-        String reservationPolicy,
-        Region region
+            Owner owner,
+            Integer price,
+            String address,
+            String detail,
+            String name,
+            Integer capacity,
+            Integer minGuest,
+            Integer maxGuest,
+            Integer parkingCapacity,
+            String cateringType,
+            String availableTimes,
+            String reservationPolicy,
+            Region region,
+            boolean subwayAccessible,
+            boolean diningAvailable
     ) {
-        super(
-            owner,
-            Category.WEDDING_HALL,
-            price,
-            address,
-            detail,
-            name,
-            availableTimes,
-            region
-        );
+        super(owner, Category.WEDDING_HALL, price, address, detail, name, availableTimes, region);
         this.capacity = capacity;
         this.minGuest = minGuest;
         this.maxGuest = maxGuest;
-        this.hallType = hallType;
         this.parkingCapacity = parkingCapacity;
         this.cateringType = cateringType;
         this.reservationPolicy = reservationPolicy;
+        this.subwayAccessible = subwayAccessible;
+        this.diningAvailable = diningAvailable;
     }
 
     public static WeddingHall create(
-        Owner owner,
-        Integer price,
-        String address,
-        String detail,
-        String name,
-        Integer capacity,
-        Integer minGuest,
-        Integer maxGuest,
-        Integer hallType,
-        Integer parkingCapacity,
-        String cateringType,
-        String availableTimes,
-        String reservationPolicy,
-        Region region
+            Owner owner,
+            Integer price,
+            String address,
+            String detail,
+            String name,
+            Integer capacity,
+            Integer minGuest,
+            Integer maxGuest,
+            Integer parkingCapacity,
+            String cateringType,
+            String availableTimes,
+            String reservationPolicy,
+            Region region,
+            boolean subwayAccessible,
+            boolean diningAvailable
     ) {
         return new WeddingHall(
-            owner,
-            price,
-            address,
-            detail,
-            name,
-            capacity,
-            minGuest,
-            maxGuest,
-            hallType,
-            parkingCapacity,
-            cateringType,
-            availableTimes,
-            reservationPolicy,
-            region
+                owner, price, address, detail, name,
+                capacity, minGuest, maxGuest, parkingCapacity,
+                cateringType, availableTimes, reservationPolicy, region,
+                subwayAccessible, diningAvailable
         );
     }
 
     public void update(
-        Integer price,
-        String address,
-        String detail,
-        String name,
-        Integer capacity,
-        Integer minGuest,
-        Integer maxGuest,
-        Integer hallType,
-        Integer parkingCapacity,
-        String cateringType,
-        String availableTimes,
-        String reservationPolicy,
-        Region region
+            Integer price,
+            String address,
+            String detail,
+            String name,
+            Integer capacity,
+            Integer minGuest,
+            Integer maxGuest,
+            Integer parkingCapacity,
+            String cateringType,
+            String availableTimes,
+            String reservationPolicy,
+            Region region,
+            boolean subwayAccessible,
+            boolean diningAvailable
     ) {
         super.updateProduct(price, address, detail, name, availableTimes, region);
         this.capacity = capacity;
         this.minGuest = minGuest;
         this.maxGuest = maxGuest;
-        this.hallType = hallType;
         this.parkingCapacity = parkingCapacity;
         this.cateringType = cateringType;
         this.reservationPolicy = reservationPolicy;
+        this.subwayAccessible = subwayAccessible;
+        this.diningAvailable = diningAvailable;
     }
-
-
 }

--- a/src/main/java/gnu/project/backend/product/repository/WeddingHallCustomRepository.java
+++ b/src/main/java/gnu/project/backend/product/repository/WeddingHallCustomRepository.java
@@ -4,23 +4,31 @@ import gnu.project.backend.product.dto.response.WeddingHallPageResponse;
 import gnu.project.backend.product.dto.response.WeddingHallResponse;
 import gnu.project.backend.product.entity.WeddingHall;
 import gnu.project.backend.product.enumerated.Region;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface WeddingHallCustomRepository {
 
     WeddingHallResponse findByWeddingHallId(final Long id);
 
-    List<WeddingHallPageResponse> searchWeddingHall(final int pageSize, final int pageNumber,
-        final Region region);
+    Page<WeddingHallPageResponse> searchWeddingHall(
+            final Pageable pageable,
+            final Region region,
+            final Boolean subwayAccessible,
+            final Boolean diningAvailable
+    );
 
-    long countActiveByRegion(final Region region);
+    long countActiveFiltered(
+            final Region region,
+            final Boolean subwayAccessible,
+            final Boolean diningAvailable
+    );
 
-    List<WeddingHallPageResponse> searchWeddingHallByOwner(
-        final String ownerSocialId,
-        final int pageSize,
-        final int pageNumber
+    Page<WeddingHallPageResponse> searchWeddingHallByOwner(
+            final String ownerSocialId,
+            final Pageable pageable
     );
 
     Optional<WeddingHall> findWeddingHallWithImagesAndOptionsById(final Long id);
@@ -28,6 +36,4 @@ public interface WeddingHallCustomRepository {
     long countActive();
 
     long countActiveByOwner(final String ownerSocialId);
-
-
 }

--- a/src/main/java/gnu/project/backend/product/repository/impl/WeddingHallRepositoryImpl.java
+++ b/src/main/java/gnu/project/backend/product/repository/impl/WeddingHallRepositoryImpl.java
@@ -1,235 +1,267 @@
 package gnu.project.backend.product.repository.impl;
 
+import static gnu.project.backend.product.entity.QImage.image;
+import static gnu.project.backend.product.entity.QTag.tag;
+import static gnu.project.backend.product.entity.QWeddingHall.weddingHall;
+
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import gnu.project.backend.product.dto.response.WeddingHallPageResponse;
 import gnu.project.backend.product.dto.response.WeddingHallResponse;
+import gnu.project.backend.product.dto.response.WeddingHallResponse.TagResponse;
+import gnu.project.backend.product.entity.Tag;
 import gnu.project.backend.product.entity.WeddingHall;
 import gnu.project.backend.product.enumerated.Region;
 import gnu.project.backend.product.repository.WeddingHallCustomRepository;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.TypedQuery;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
-@Repository
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class WeddingHallRepositoryImpl implements WeddingHallCustomRepository {
 
-    @PersistenceContext
-    private EntityManager em;
+    // 최신순 (updatedAt desc → id desc)
+    private static final OrderSpecifier<?>[] HALL_DEFAULT_ORDER = {
+            weddingHall.updatedAt.desc(),
+            weddingHall.id.desc()
+    };
 
+    private final JPAQueryFactory query;
+
+    /** 상세 조회: MultipleBagFetchException 회피를 위해 이미지만 fetch join */
     @Override
     public WeddingHallResponse findByWeddingHallId(final Long id) {
-        final TypedQuery<WeddingHall> query = em.createQuery(
-            """
-                SELECT DISTINCT w
-                FROM WeddingHall w
-                LEFT JOIN FETCH w.owner o
-                LEFT JOIN FETCH w.images imgs
-                WHERE w.id = :id
-                  AND w.isDeleted = false
-                """,
-            WeddingHall.class
-        );
-        query.setParameter("id", id);
-
-        final List<WeddingHall> result = query.getResultList();
-        if (result.isEmpty()) {
-            return null; // 서비스에서 null 체크 후 BusinessException 던질 예정
-        }
-
-        final WeddingHall hall = result.get(0);
-        return WeddingHallResponse.from(hall);
-    }
-
-
-    @Override
-    public List<WeddingHallPageResponse> searchWeddingHall(
-        final int pageSize,
-        final int pageNumber,
-        final Region region
-    ) {
-        final int offset = (pageNumber - 1) * pageSize;
-
-        String jpql = """
-                SELECT DISTINCT w
-                FROM WeddingHall w
-                LEFT JOIN FETCH w.owner o
-                LEFT JOIN FETCH w.tags t
-                WHERE w.isDeleted = false
-            """;
-
-        if (region != null) {
-            jpql += " AND w.region = :region ";
-        }
-
-        jpql += " ORDER BY w.id DESC ";
-
-        final TypedQuery<WeddingHall> query = em.createQuery(jpql, WeddingHall.class);
-
-        if (region != null) {
-            query.setParameter("region", region);
-        }
-
-        query.setFirstResult(offset);
-        query.setMaxResults(pageSize);
-
-        final List<WeddingHall> halls = query.getResultList();
-
-        return halls.stream()
-            .map(hall ->
-                new WeddingHallPageResponse(
-                    hall.getId(),
-                    hall.getName(),
-                    hall.getStarCount(),
-                    hall.getAddress(),
-                    hall.getDetail(),
-                    hall.getPrice(),
-                    hall.getHallType(),
-                    hall.getAvailableTimes(),
-                    hall.getCreatedAt(),
-                    hall.getThumbnailUrl(),
-                    hall.getRegion(),
-                    hall.getTags().stream()
-                        .map(tag -> new WeddingHallResponse.TagResponse(
-                            tag.getId(),
-                            tag.getName()
-                        ))
-                        .toList()
+        final WeddingHall hall = query
+                .selectFrom(weddingHall)
+                .leftJoin(weddingHall.images, image).fetchJoin()
+                .where(
+                        weddingHall.id.eq(id),
+                        weddingHall.isDeleted.isFalse()
                 )
-            )
-            .toList();
+                .fetchOne();
+
+        return WeddingHallResponse.from(Objects.requireNonNull(hall));
     }
 
+    /** 공개 목록 + 필터(지역/지하철/식사) + 최신순 */
     @Override
-    public long countActiveByRegion(final Region region) {
-        String jpql = """
-                SELECT COUNT(w)
-                FROM WeddingHall w
-                WHERE w.isDeleted = false
-            """;
-
-        if (region != null) {
-            jpql += " AND w.region = :region ";
-        }
-
-        final TypedQuery<Long> query = em.createQuery(jpql, Long.class);
-
-        if (region != null) {
-            query.setParameter("region", region);
-        }
-
-        return query.getSingleResult();
-    }
-
-
-    @Override
-    public List<WeddingHallPageResponse> searchWeddingHallByOwner(
-        final String ownerSocialId,
-        final int pageSize,
-        final int pageNumber
+    public Page<WeddingHallPageResponse> searchWeddingHall(
+            final Pageable pageable,
+            final Region region,
+            final Boolean subwayAccessible,
+            final Boolean diningAvailable
     ) {
-        final int offset = (pageNumber - 1) * pageSize;
+        final List<WeddingHallPageResponse> halls = pagination(
+                query
+                        .select(createPageProjection())
+                        .from(weddingHall)
+                        .leftJoin(weddingHall.images, image)
+                        .where(
+                                weddingHall.isDeleted.isFalse(),
+                                region != null ? weddingHall.region.eq(region) : null,
+                                subwayAccessible != null
+                                        ? (subwayAccessible ? weddingHall.subwayAccessible.isTrue()
+                                        : weddingHall.subwayAccessible.isFalse())
+                                        : null,
+                                diningAvailable != null
+                                        ? (diningAvailable ? weddingHall.diningAvailable.isTrue()
+                                        : weddingHall.diningAvailable.isFalse())
+                                        : null,
+                                image.displayOrder.eq(0).or(image.isNull())
+                        )
+                        .orderBy(HALL_DEFAULT_ORDER),
+                pageable
+        ).fetch();
 
-        final TypedQuery<WeddingHall> query = em.createQuery(
-            """
-                SELECT DISTINCT w
-                FROM WeddingHall w
-                LEFT JOIN FETCH w.owner o
-                LEFT JOIN FETCH w.tags t
-                WHERE w.isDeleted = false
-                  AND o.oauthInfo.socialId = :socialId
-                ORDER BY w.id DESC
-                """,
-            WeddingHall.class
+        if (halls.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        final Map<Long, List<TagResponse>> tagsMap = loadTagsGroupedByProductId(
+                halls.stream().map(WeddingHallPageResponse::id).toList()
         );
-        query.setParameter("socialId", ownerSocialId);
-        query.setFirstResult(offset);
-        query.setMaxResults(pageSize);
 
-        final List<WeddingHall> halls = query.getResultList();
+        final List<WeddingHallPageResponse> withTags = halls.stream()
+                .map(h -> new WeddingHallPageResponse(
+                        h.id(),
+                        h.name(),
+                        h.starCount(),
+                        h.address(),
+                        h.detail(),
+                        h.price(),
+                        h.availableTime(),
+                        h.createdAt(),
+                        h.thumbnail(),
+                        h.region(),
+                        h.ownerName(),
+                        h.subwayAccessible(),
+                        h.diningAvailable(),
+                        tagsMap.getOrDefault(h.id(), List.of())
+                ))
+                .toList();
 
-        return halls.stream()
-            .map(hall ->
-                new WeddingHallPageResponse(
-                    hall.getId(),
-                    hall.getName(),
-                    hall.getStarCount(),
-                    hall.getAddress(),
-                    hall.getDetail(),
-                    hall.getPrice(),
-                    hall.getHallType(),
-                    hall.getAvailableTimes(),
-                    hall.getCreatedAt(),
-                    hall.getThumbnailUrl(),
-                    hall.getRegion(),
-                    hall.getTags().stream()
-                        .map(tag -> new WeddingHallResponse.TagResponse(
-                            tag.getId(),
-                            tag.getName()
-                        ))
-                        .toList()
-                )
-            )
-            .toList();
+        final long total = countActiveFiltered(region, subwayAccessible, diningAvailable);
+        return new PageImpl<>(withTags, pageable, total);
     }
 
+    /** 총합(필터 적용) */
+    @Override
+    public long countActiveFiltered(
+            final Region region,
+            final Boolean subwayAccessible,
+            final Boolean diningAvailable
+    ) {
+        final Long cnt = query
+                .select(weddingHall.count())
+                .from(weddingHall)
+                .where(
+                        weddingHall.isDeleted.isFalse(),
+                        region != null ? weddingHall.region.eq(region) : null,
+                        subwayAccessible != null
+                                ? (subwayAccessible ? weddingHall.subwayAccessible.isTrue()
+                                : weddingHall.subwayAccessible.isFalse())
+                                : null,
+                        diningAvailable != null
+                                ? (diningAvailable ? weddingHall.diningAvailable.isTrue()
+                                : weddingHall.diningAvailable.isFalse())
+                                : null
+                )
+                .fetchOne();
+        return cnt != null ? cnt : 0L;
+    }
+
+    /** 오너 전용 목록 */
+    @Override
+    public Page<WeddingHallPageResponse> searchWeddingHallByOwner(
+            final String ownerSocialId,
+            final Pageable pageable
+    ) {
+        final List<WeddingHallPageResponse> halls = pagination(
+                query
+                        .select(createPageProjection())
+                        .from(weddingHall)
+                        .leftJoin(weddingHall.images, image)
+                        .where(
+                                weddingHall.isDeleted.isFalse(),
+                                weddingHall.owner.oauthInfo.socialId.eq(ownerSocialId),
+                                image.displayOrder.eq(0).or(image.isNull())
+                        )
+                        .orderBy(HALL_DEFAULT_ORDER),
+                pageable
+        ).fetch();
+
+        if (halls.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        final Map<Long, List<TagResponse>> tagsMap = loadTagsGroupedByProductId(
+                halls.stream().map(WeddingHallPageResponse::id).toList()
+        );
+
+        final List<WeddingHallPageResponse> withTags = halls.stream()
+                .map(h -> new WeddingHallPageResponse(
+                        h.id(),
+                        h.name(),
+                        h.starCount(),
+                        h.address(),
+                        h.detail(),
+                        h.price(),
+                        h.availableTime(),
+                        h.createdAt(),
+                        h.thumbnail(),
+                        h.region(),
+                        h.ownerName(),
+                        h.subwayAccessible(),
+                        h.diningAvailable(),
+                        tagsMap.getOrDefault(h.id(), List.of())
+                ))
+                .toList();
+
+        final long total = countActiveByOwner(ownerSocialId);
+        return new PageImpl<>(withTags, pageable, total);
+    }
 
     @Override
     public Optional<WeddingHall> findWeddingHallWithImagesAndOptionsById(final Long id) {
-        final TypedQuery<WeddingHall> query = em.createQuery(
-            """
-                SELECT DISTINCT w
-                FROM WeddingHall w
-                LEFT JOIN FETCH w.owner o
-                LEFT JOIN FETCH w.images imgs
-                WHERE w.id = :id
-                  AND w.isDeleted = false
-                """,
-            WeddingHall.class
+        return Optional.ofNullable(
+                query
+                        .selectFrom(weddingHall)
+                        .leftJoin(weddingHall.images, image).fetchJoin()
+                        .where(
+                                weddingHall.id.eq(id),
+                                weddingHall.isDeleted.isFalse()
+                        )
+                        .fetchOne()
         );
-
-        query.setParameter("id", id);
-        final List<WeddingHall> result = query.getResultList();
-
-        if (result.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(result.get(0));
     }
-
 
     @Override
     public long countActive() {
-        final TypedQuery<Long> query = em.createQuery(
-            """
-                SELECT COUNT(w)
-                FROM WeddingHall w
-                WHERE w.isDeleted = false
-                """,
-            Long.class
-        );
-        return query.getSingleResult();
+        final Long cnt = query
+                .select(weddingHall.count())
+                .from(weddingHall)
+                .where(weddingHall.isDeleted.isFalse())
+                .fetchOne();
+        return cnt != null ? cnt : 0L;
     }
 
     @Override
     public long countActiveByOwner(final String ownerSocialId) {
-        final TypedQuery<Long> query = em.createQuery(
-            """
-                SELECT COUNT(w)
-                FROM WeddingHall w
-                JOIN w.owner o
-                WHERE w.isDeleted = false
-                  AND o.oauthInfo.socialId = :socialId
-                """,
-            Long.class
+        final Long cnt = query
+                .select(weddingHall.count())
+                .from(weddingHall)
+                .where(
+                        weddingHall.isDeleted.isFalse(),
+                        weddingHall.owner.oauthInfo.socialId.eq(ownerSocialId)
+                )
+                .fetchOne();
+        return cnt != null ? cnt : 0L;
+    }
+
+    private ConstructorExpression<WeddingHallPageResponse> createPageProjection() {
+        return Projections.constructor(
+                WeddingHallPageResponse.class,
+                weddingHall.id,                               // Long id
+                weddingHall.name,                             // String name
+                weddingHall.starCount,                        // Double starCount
+                weddingHall.address,                          // String address
+                weddingHall.detail,                           // String detail
+                weddingHall.price,                            // Integer price
+                weddingHall.availableTimes,                   // String availableTime
+                weddingHall.createdAt,                        // LocalDateTime createdAt
+                image.url,                                    // String thumbnail (displayOrder=0)
+                weddingHall.region,                           // Region region
+                weddingHall.owner.bzName.coalesce(weddingHall.owner.oauthInfo.name),
+                weddingHall.subwayAccessible,
+                weddingHall.diningAvailable,
+                Expressions.nullExpression(List.class)
         );
-        query.setParameter("socialId", ownerSocialId);
-        return query.getSingleResult();
+    }
+
+    private <T> JPAQuery<T> pagination(final JPAQuery<T> q, final Pageable pageable) {
+        return q.offset(pageable.getOffset()).limit(pageable.getPageSize());
+    }
+
+    private Map<Long, List<TagResponse>> loadTagsGroupedByProductId(final List<Long> productIds) {
+        final List<Tag> allTags = query
+                .selectFrom(tag)
+                .where(tag.product.id.in(productIds))
+                .fetch();
+
+        return allTags.stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.getProduct().getId(),
+                        Collectors.mapping(TagResponse::from, Collectors.toList())
+                ));
     }
 }

--- a/src/main/java/gnu/project/backend/product/service/WeddingHallService.java
+++ b/src/main/java/gnu/project/backend/product/service/WeddingHallService.java
@@ -19,7 +19,6 @@ import gnu.project.backend.product.repository.WeddingHallRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -42,163 +41,126 @@ public class WeddingHallService {
 
     private Owner findOwnerBySocialId(final Accessor accessor) {
         return ownerRepository.findByOauthInfo_SocialId(accessor.getSocialId())
-            .orElseThrow(() -> new BusinessException(OWNER_NOT_FOUND_EXCEPTION));
+                .orElseThrow(() -> new BusinessException(OWNER_NOT_FOUND_EXCEPTION));
     }
-
 
     @Transactional(readOnly = true)
     public WeddingHallResponse read(final Long id) {
         final WeddingHallResponse hall = weddingHallRepository.findByWeddingHallId(id);
-        if (hall == null) {
-            throw new BusinessException(WEDDING_HALL_NOT_FOUND_EXCEPTION);
-        }
+        if (hall == null) throw new BusinessException(WEDDING_HALL_NOT_FOUND_EXCEPTION);
         return hall;
     }
 
     @Transactional(readOnly = true)
     public Page<WeddingHallPageResponse> readWeddingHalls(
-        final Integer pageNumber,
-        final Integer pageSize,
-        final Region region
+            final Integer pageNumber,
+            final Integer pageSize,
+            final Region region,
+            final Boolean subwayAccessible,
+            final Boolean diningAvailable
     ) {
-        final long totalElements = weddingHallRepository.countActiveByRegion(region);
-
         final Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
-
-        final List<WeddingHallPageResponse> pageContent =
-            weddingHallRepository.searchWeddingHall(pageSize, pageNumber, region);
-
-        return new PageImpl<>(
-            pageContent,
-            pageable,
-            totalElements
-        );
+        return weddingHallRepository.searchWeddingHall(pageable, region, subwayAccessible, diningAvailable);
     }
-
 
     @Transactional(readOnly = true)
     public Page<WeddingHallPageResponse> readMyWeddingHalls(
-        final Accessor accessor,
-        final Integer pageNumber,
-        final Integer pageSize
+            final Accessor accessor,
+            final Integer pageNumber,
+            final Integer pageSize
     ) {
-        final String socialId = accessor.getSocialId();
-
-        final long totalElements = weddingHallRepository.countActiveByOwner(socialId);
-
         final Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
-
-        final List<WeddingHallPageResponse> pageContent =
-            weddingHallRepository.searchWeddingHallByOwner(
-                socialId,
-                pageSize,
-                pageNumber
-            );
-
-        return new PageImpl<>(
-            pageContent,
-            pageable,
-            totalElements
-        );
+        return weddingHallRepository.searchWeddingHallByOwner(accessor.getSocialId(), pageable);
     }
-
 
     @Transactional
     public WeddingHallResponse create(
-        final WeddingHallRequest request,
-        final List<MultipartFile> images,
-        final Accessor accessor
+            final WeddingHallRequest request,
+            final List<MultipartFile> images,
+            final Accessor accessor
     ) {
-        // 1) 현재 로그인한 Owner를 가져온다
         final Owner owner = findOwnerBySocialId(accessor);
 
-        // 2) 엔티티 생성
         final WeddingHall hall = WeddingHall.create(
-            owner,
-            request.price(),
-            request.address(),
-            request.detail(),
-            request.name(),
-            request.capacity(),
-            request.minGuest(),
-            request.maxGuest(),
-            request.hallType(),
-            request.parkingCapacity(),
-            request.cateringType(),
-            request.availableTimes(),
-            request.reservationPolicy(),
-            request.region()
+                owner,
+                request.price(),
+                request.address(),
+                request.detail(),
+                request.name(),
+                request.capacity(),
+                request.minGuest(),
+                request.maxGuest(),
+                request.parkingCapacity(),
+                request.cateringType(),
+                request.availableTimes(),
+                request.reservationPolicy(),
+                request.region(),
+                request.subwayAccessible(),
+                request.diningAvailable()
         );
 
         final WeddingHall saved = weddingHallRepository.save(hall);
 
         productHelper.createProduct(
-            hall,
-            images,
-            request.options(),
-            request.tags()
+                hall,
+                images,
+                request.options(),
+                request.tags()
         );
 
         return WeddingHallResponse.from(saved);
     }
 
-
     @Transactional
     public WeddingHallResponse update(
-        final Long id,
-        final WeddingHallUpdateRequest request,
-        final List<MultipartFile> newImages,
-        final List<Long> keepImagesId,
-        final Accessor accessor
+            final Long id,
+            final WeddingHallUpdateRequest request,
+            final List<MultipartFile> newImages,
+            final List<Long> keepImagesId,
+            final Accessor accessor
     ) {
-
         final WeddingHall hall = weddingHallRepository
-            .findWeddingHallWithImagesAndOptionsById(id)
-            .orElseThrow(() -> new BusinessException(WEDDING_HALL_NOT_FOUND_EXCEPTION));
+                .findWeddingHallWithImagesAndOptionsById(id)
+                .orElseThrow(() -> new BusinessException(WEDDING_HALL_NOT_FOUND_EXCEPTION));
 
         validateOwner(accessor, hall);
 
         productHelper.updateProductEnrichment(
-            hall,
-            newImages,
-            keepImagesId,
-            request.options(),
-            request.tags()
+                hall,
+                newImages,
+                keepImagesId,
+                request.options(),
+                request.tags()
         );
 
         hall.update(
-            request.price(),
-            request.address(),
-            request.detail(),
-            request.name(),
-            request.capacity(),
-            request.minGuest(),
-            request.maxGuest(),
-            request.hallType(),
-            request.parkingCapacity(),
-            request.cateringType(),
-            request.availableTimes(),
-            request.reservationPolicy(),
-            request.region()
+                request.price(),
+                request.address(),
+                request.detail(),
+                request.name(),
+                request.capacity(),
+                request.minGuest(),
+                request.maxGuest(),
+                request.parkingCapacity(),
+                request.cateringType(),
+                request.availableTimes(),
+                request.reservationPolicy(),
+                request.region(),
+                request.subwayAccessible(),
+                request.diningAvailable()
         );
 
         return WeddingHallResponse.from(hall);
     }
 
-
     @Transactional
-    public String delete(
-        final Long id,
-        final Accessor accessor
-    ) {
+    public String delete(final Long id, final Accessor accessor) {
         final WeddingHall hall = weddingHallRepository
-            .findById(id)
-            .orElseThrow(() -> new BusinessException(WEDDING_HALL_NOT_FOUND_EXCEPTION));
+                .findById(id)
+                .orElseThrow(() -> new BusinessException(WEDDING_HALL_NOT_FOUND_EXCEPTION));
 
         validateOwner(accessor, hall);
-
         hall.delete();
-
         return WEDDING_HALL_DELETE_SUCCESS;
     }
 }


### PR DESCRIPTION
작업 요약

- 웨딩홀 도메인 전반 리팩토링: 필터링(지하철/식사), 최신순 정렬(updatedAt desc, id desc), Page 기반 페이징으로 무한스크롤 대응.

- N+1 및 MultipleBagFetchException 회피를 고려한 QueryDSL 프로젝션/조인 전략 정비.

- 응답에 업체명(owner.bzName → fallback oauth.name) 포함.

- 생성/수정 멀티파트 로직 정리(Swagger 한정 이슈 주석) 및 공통 헬퍼 활용.

1) 엔티티/스키마
- WeddingHall
- 컬럼 추가:

- subway_accessible (boolean, not null)

- dining_available (boolean, not null)

- hallType 제거 (미사용 메타데이터 정리)

- Product(기존)

- updatedAt 기반 정렬을 위해 상속 컬럼 사용 (변경 없음)


2) DTO

- WeddingHallRequest, WeddingHallUpdateRequest

- 필드 추가: subwayAccessible: boolean, diningAvailable: boolean

- 나머지 필드는 기존 유지(availableTimes, region 등)

- WeddingHallPageResponse

- 필드 추가: ownerName, subwayAccessible, diningAvailable

- 썸네일/태그/region/별점 등 기존 필드 유지

- WeddingHallResponse

- 상세에서 업체명(owner.bzName or oauth.name) 노출

3) Repository/Query (QueryDSL)

- WeddingHallRepositoryImpl

- 목록: searchWeddingHall(Pageable, region, subway, dining)

- 조건부 where (null-safe), 썸네일만 조인.

- 정렬: updatedAt DESC, id DESC(안정 정렬)

- 상세: findByWeddingHallId(Long)

- images만 fetchJoin → MultipleBagFetchException 회피

-  오너 목록: searchWeddingHallByOwner(ownerSocialId, pageable)

-  카운트: countActiveFiltered(...), countActiveByOwner(...)

-  프로젝션: ownerName = owner.bzName.coalesce(owner.oauthInfo.name)


목데이터/로컬 시드 (선택)

- 로컬 프로파일(local)에서 토큰 socialId(예: NAVER: sAkPP...Ncs) 기반 오너 생성/재사용하도록 수정





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 웨딩홀 검색에 지하철 접근성 및 식사 제공 여부 필터 추가
  * 웨딩홀 목록에 오너 이름 표시

* **설명서**
  * API 문서 업데이트로 새로운 필터 옵션 반영

<!-- end of auto-generated comment: release notes by coderabbit.ai -->