### PR TITLE
[Payment] 오너 결제 취소 목록 조회 (단순 추가)

### DIFF
--- a/src/main/java/gnu/project/backend/payment/controller/PaymentController.java
+++ b/src/main/java/gnu/project/backend/payment/controller/PaymentController.java
@@ -72,6 +72,14 @@ public class PaymentController implements PaymentDocs {
     }
 
     @Override
+    @GetMapping("/cancels/me")
+    public ResponseEntity<List<PaymentCancelResponse>> getMyCanceledPayments(
+            @Auth Accessor accessor
+    ) {
+        return ResponseEntity.ok(paymentQueryService.getMyCanceledPayments(accessor));
+    }
+
+    @Override
     @GetMapping("/me")
     public ResponseEntity<List<PaymentListResponse>> getMyPayments(
             @Auth Accessor accessor,

--- a/src/main/java/gnu/project/backend/payment/controller/docs/PaymentDocs.java
+++ b/src/main/java/gnu/project/backend/payment/controller/docs/PaymentDocs.java
@@ -80,4 +80,9 @@ public interface PaymentDocs {
     ResponseEntity<List<PaymentCancelResponse>> getMyCancelRequests(
             @Parameter(hidden = true) Accessor accessor
     );
+
+    @Operation(summary = "결제 취소 목록(사장)", description = "CANCELED 상태의 결제들만 조회")
+    ResponseEntity<List<PaymentCancelResponse>> getMyCanceledPayments(
+            @Parameter(hidden = true) Accessor accessor
+    );
 }

--- a/src/main/java/gnu/project/backend/payment/repository/PaymentRepositoryCustom.java
+++ b/src/main/java/gnu/project/backend/payment/repository/PaymentRepositoryCustom.java
@@ -18,4 +18,7 @@ public interface PaymentRepositoryCustom {
 
     //사장 취소 요청 목록 조회
     List<Payment> findAllCancelRequestedWithOrderAndDetailsByOwnerId(Long ownerId);
+
+    //사장 취소 목록 조회
+    List<Payment> findAllCanceledWithOrderAndDetailsByOwnerId(Long ownerId);
 }

--- a/src/main/java/gnu/project/backend/payment/repository/PaymentRepositoryImpl.java
+++ b/src/main/java/gnu/project/backend/payment/repository/PaymentRepositoryImpl.java
@@ -119,4 +119,22 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<Payment> findAllCanceledWithOrderAndDetailsByOwnerId(Long ownerId) {
+        return query
+                .selectFrom(payment)
+                .distinct()
+                .join(payment.order, order).fetchJoin()
+                .join(order.customer, customer).fetchJoin()
+                .leftJoin(order.orderDetails, orderDetail).fetchJoin()
+                .leftJoin(orderDetail.product, product).fetchJoin()
+                .join(product.owner, owner).fetchJoin()
+                .where(
+                        owner.id.eq(ownerId),
+                        payment.status.eq(PaymentStatus.CANCELED)
+                )
+                .orderBy(payment.canceledAt.desc().nullsLast(), payment.approvedAt.desc())
+                .fetch();
+    }
+
 }

--- a/src/main/java/gnu/project/backend/payment/service/PaymentQueryService.java
+++ b/src/main/java/gnu/project/backend/payment/service/PaymentQueryService.java
@@ -189,6 +189,16 @@ public class PaymentQueryService {
             .toList();
     }
 
+    public List<PaymentCancelResponse> getMyCanceledPayments(Accessor accessor) {
+        Owner owner = ownerRepository.findByOauthInfo_SocialId(accessor.getSocialId())
+                .orElseThrow(() -> new BusinessException(OWNER_NOT_FOUND_EXCEPTION));
+
+        return paymentRepository.findAllCanceledWithOrderAndDetailsByOwnerId(owner.getId())
+                .stream()
+                .map(PaymentCancelResponse::from)
+                .toList();
+    }
+
     private <T> List<T> applyPaging(List<T> list, int page, int size) {
         if (size <= 0) {
             return list;


### PR DESCRIPTION
## 작업 내용
payment.status canceled  단순조회 api 추가





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제 취소 목록 조회 기능 추가: 사용자가 자신의 취소된 결제 내역을 새로운 API를 통해 조회할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->